### PR TITLE
fix(platform): fix for #56

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,5 @@ import { DingzDaHomebridgePlatform } from './platform';
  * This method registers the platform with Homebridge
  */
 export = (api: API) => {
-  api.registerPlatform(PLATFORM_NAME, DingzDaHomebridgePlatform);
+  api.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, DingzDaHomebridgePlatform);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { API } from 'homebridge';
+import type { API } from 'homebridge';
 
 import { PLATFORM_NAME } from './settings';
 import { PLUGIN_NAME } from './settings';
@@ -7,6 +7,6 @@ import { DingzDaHomebridgePlatform } from './platform';
 /**
  * This method registers the platform with Homebridge
  */
-export default function(api: API) {
-  api.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, DingzDaHomebridgePlatform);
-}
+export = (api: API) => {
+  api.registerPlatform(PLATFORM_NAME, DingzDaHomebridgePlatform);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,4 @@ import { DingzDaHomebridgePlatform } from './platform';
  */
 export default function(api: API) {
   api.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, DingzDaHomebridgePlatform);
-};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
-import type { API } from 'homebridge';
+import { API } from 'homebridge';
 
 import { PLATFORM_NAME } from './settings';
+import { PLUGIN_NAME } from './settings';
 import { DingzDaHomebridgePlatform } from './platform';
 
 /**
  * This method registers the platform with Homebridge
  */
-export = (api: API) => {
-  api.registerPlatform(PLATFORM_NAME, DingzDaHomebridgePlatform);
+export default function(api: API) {
+  api.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, DingzDaHomebridgePlatform);
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,6 +2,7 @@
  * This is the name of the platform that users will use to register the plugin in the Homebridge config.json
  */
 export const PLATFORM_NAME = 'Dingz';
+export const PLUGIN_NAME = 'homebridge-dingz';
 export const ACCESSORY_NAME = 'Da';
 export const DINGZ_DISCOVERY_PORT = 7979;
 export const DINGZ_CALLBACK_PORT = 18081;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,7 +2,6 @@
  * This is the name of the platform that users will use to register the plugin in the Homebridge config.json
  */
 export const PLATFORM_NAME = 'Dingz';
-export const PLUGIN_NAME = 'homebridge-dingz';
 export const ACCESSORY_NAME = 'Da';
 export const DINGZ_DISCOVERY_PORT = 7979;
 export const DINGZ_CALLBACK_PORT = 18081;


### PR DESCRIPTION
- Expand platform registration to include plugin name besides platform name (See #56 and also https://github.com/homebridge/homebridge-plugin-template/issues/11)