### PR TITLE
feat(dingz): dynamic output configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge dingz Plugin",
   "name": "homebridge-dingz",
-  "version": "2.0.8-rc.3",
+  "version": "2.1.0-nightly.0",
   "author": "johannrichard",
   "description": "Homebridge Plugin for dingz & myStrom Devices. Implements some (but not all, due to API limitations) functions of a [dingz](https://dingz.ch) Smart Home Device.",
   "license": "Apache-2.0",

--- a/src/lib/commonTypes.ts
+++ b/src/lib/commonTypes.ts
@@ -48,7 +48,7 @@ export interface DeviceInfo {
   dimmerConfig?: DingzDeviceDimmerConfig;
   windowCoveringConfig?: DingzWindowCoveringConfigItem[];
   dingzInputInfo?: DingzInputInfoItem[];
-  lastUpdate?: Date;
+  configTimestamp?: number;
   accessoryClass?:
     | 'DingzDaAccessory'
     | 'MyStromSwitchAccessory'

--- a/src/lib/dingzDaBaseAccessory.ts
+++ b/src/lib/dingzDaBaseAccessory.ts
@@ -127,7 +127,6 @@ export class DingzDaBaseAccessory {
           // Set accessory to reachable and
           // updateAccessory()
           this.reachabilityState = null;
-          this.updateAccessory();
         }
       },
     );
@@ -135,13 +134,6 @@ export class DingzDaBaseAccessory {
 
   // Override these if specific actions needed on updates on restore
   protected setAccessoryInformation(): void {
-    this.log.debug(
-      'setAccessoryInformation() not implemented for',
-      this.device.accessoryClass,
-    );
-  }
-
-  protected updateAccessory(): void {
     this.log.debug(
       'setAccessoryInformation() not implemented for',
       this.device.accessoryClass,

--- a/src/lib/dingzDaBaseAccessory.ts
+++ b/src/lib/dingzDaBaseAccessory.ts
@@ -125,7 +125,6 @@ export class DingzDaBaseAccessory {
           }
 
           // Set accessory to reachable and
-          // updateAccessory()
           this.reachabilityState = null;
         }
       },

--- a/src/lib/dingzTypes.ts
+++ b/src/lib/dingzTypes.ts
@@ -59,7 +59,8 @@ export interface DingzDeviceSystemConfig {
 }
 
 // Internal representation of Dimmer in Plugin
-export type DimmerId = 0 | 1 | 2 | 3;
+export type DimmerId = 'D1' | 'D2' | 'D3' | 'D4';
+export type DimmerIndex = 0 | 1 | 2 | 3;
 export type ButtonId = '1' | '2' | '3' | '4';
 export enum ButtonState {
   OFF = 0,
@@ -77,7 +78,7 @@ export interface DimmerState {
     absolute: number;
   };
 }
-export type DimmerProps = Record<DimmerId, DimmerState>;
+export type DimmerProps = Record<DimmerIndex, DimmerState>;
 
 export interface DingzLEDState {
   on: boolean;


### PR DESCRIPTION
- use the `config` timestap in state endpoint
- only call `updateAccessory()` in case timestamp differs
- save timestamp to accessory cache
- reduced hitting and updating
- big refactoring of output configuration
- dynamic accessory creation & destruction
- setup/tear-down of event handlers
- brings a lot of stability and cleaner code

BREAKING CHANGE: *might* break your setup