### PR TITLE
ci(github): :green_heart: fix semantic-release script

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -11,11 +11,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Upgrade yarn
-        run: yarn set version berry
+      #      - name: Upgrade yarn
+      #        run: yarn set version berry
+      #
+      #      - name: Install dependencies
+      #        run: yarn
 
       - name: Install dependencies
-        run: yarn
+        run: npm install
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2


### PR DESCRIPTION
- rollback to npm install instead of yarn